### PR TITLE
[fix] React Router Link 및 Span 컴포넌트에서 사용자 정의 속성 제거

### DIFF
--- a/src/layout/Menu/MenuItem.tsx
+++ b/src/layout/Menu/MenuItem.tsx
@@ -5,7 +5,7 @@ import { colors } from '@/constants/colors';
 
 const MenuItem = ({ to, icon, label, isActive }: IMenuItemProps) => (
 	<MenuItemContainer>
-		<StyledLink to={to} isActive={isActive}>
+		<StyledLink to={to} className={isActive ? 'active' : ''}>
 			<IconWrapper>{icon}</IconWrapper>
 			<LinkText isActive={isActive}>{label}</LinkText>
 		</StyledLink>
@@ -19,14 +19,19 @@ const MenuItemContainer = styled.li`
 	align-items: center;
 `;
 
-const StyledLink = styled(Link)<{ isActive: boolean }>`
+const StyledLink = styled(Link)`
 	display: flex;
 	align-items: center;
 	flex-direction: column;
-	color: ${({ isActive }) => (isActive ? colors.black : colors.gray)};
 	text-decoration: none;
+	color: ${colors.gray};
+
+	&.active {
+		color: ${colors.black};
+	}
+
 	&:hover {
-		color: ${({ isActive }) => (isActive ? colors.black : colors.gray)};
+		color: ${colors.black};
 	}
 `;
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**React Router Link 및 Span 컴포넌트에서 사용자 정의 속성 제거**

## 📋 작업 내용

- `StyledLink` 컴포넌트에서 `isActive` 속성을 사용하지 않고, `className`을 이용해 'active' 클래스를 조건부로 적용합니다.
- `LinkText` 컴포넌트는 emotion의 props를 이용해 `isActive` 속성을 조건부로 적용하며, 이에 따라 스타일 정의를 수정하여 `active` 클래스가 있을 때와 없을 때의 색상 처리를 구분하도록 했습니다.

## 🔧 변경 사항
- `StyledLink` 컴포넌트에서 `className`을 이용해 'active' 클래스를 조건부로 적용하는 방식으로 변경했습니다.
- `LinkText` 컴포넌트의 emotion 스타일 정의에서 `isActive`를 이용해 색상을 조건부로 처리하도록 했습니다.
- 이에 따라 `StyledLink`와 `LinkText`의 스타일 정의를 수정하여 `active` 클래스가 있을 때와 없을 때의 색상 처리를 구분하도록 했습니다.



## 📸 스크린샷 (선택 사항)
![Aug-01-2024 14-33-28](https://github.com/user-attachments/assets/6caf9b15-909d-48e7-a904-884ac7c2bf07)

