### PR TITLE
[feature] 급여, 프로필 페이지 API 구현

### DIFF
--- a/src/api/common/getDocsByUserId.ts
+++ b/src/api/common/getDocsByUserId.ts
@@ -1,7 +1,7 @@
 import { db } from '@/firebaseConfig';
 import { collection, query, where, getDocs } from 'firebase/firestore';
 
-type TDocName = 'User' | 'Officialschedules' | 'PersonalSchedules' | 'WorkCorrections';
+type TDocName = 'User' | 'OfficialSchedules' | 'PersonalSchedules' | 'WorkCorrections';
 
 // Firestore DB에서 UID 값에 해당하는 데이터를 조회하는 로직
 const getDocsByUserId = async (docName: TDocName, userId: string) => {

--- a/src/api/schedule/getOfficialSchedule.ts
+++ b/src/api/schedule/getOfficialSchedule.ts
@@ -8,7 +8,7 @@ const getOfficialSchedule = async (year: number, month: number) => {
 	const endOfMonth = new Date(year, month, 0, 23, 59, 59);
 
 	const q = query(
-		collection(db, 'Officialschedules'),
+		collection(db, 'OfficialSchedules'),
 		where('userId', '==', getUserId()),
 		where('date', '>=', startOfMonth),
 		where('date', '<=', endOfMonth),

--- a/src/api/user/getUserInfo.ts
+++ b/src/api/user/getUserInfo.ts
@@ -1,1 +1,24 @@
+import { db } from '@/firebaseConfig';
+import { collection, query, where, getDocs } from 'firebase/firestore';
+import getUserId from '@/api/common/getUserId';
+
 // 회원 정보 조회
+const getUserInfo = async () => {
+	const q = query(collection(db, 'User'), where('userId', '==', getUserId()));
+	const querySnapshot = await getDocs(q);
+	const docData = querySnapshot.docs.map((doc) => doc.data());
+	const userInfoData = docData.map((obj) => {
+		const newObj = {
+			name: obj.name,
+			workPlace: obj.workPlace,
+			workingSets: obj.workingSets,
+		};
+		return newObj;
+	});
+
+	return {
+		userInfo: userInfoData[0],
+	};
+};
+
+export default getUserInfo;

--- a/src/api/work/createCorrection.ts
+++ b/src/api/work/createCorrection.ts
@@ -1,1 +1,32 @@
+import { db } from '@/firebaseConfig';
+import { collection, addDoc } from 'firebase/firestore';
+import getUserId from '@/api/common/getUserId';
+
+type TWorkingTimes = 'open' | 'middle' | 'close';
+type TType = 'cover' | 'special' | 'vacation' | 'early';
+
 // 근무 정정신청
+const createCorrection = async (
+	workDate: string,
+	workingTimes: TWorkingTimes,
+	type: TType,
+	description: string,
+) => {
+	try {
+		await addDoc(collection(db, 'WorkCorrections'), {
+			userId: getUserId(),
+			workDate: new Date(workDate),
+			requestDate: new Date(),
+			workingTimes,
+			type,
+			approveStatus: 'pending',
+			description,
+		});
+
+		return true;
+	} catch (error) {
+		return false;
+	}
+};
+
+export default createCorrection;

--- a/src/api/work/getCorrection.ts
+++ b/src/api/work/getCorrection.ts
@@ -1,1 +1,27 @@
+import { db } from '@/firebaseConfig';
+import { collection, query, where, getDocs } from 'firebase/firestore';
+import getUserId from '@/api/common/getUserId';
+
 // 근무 정정신청 내역 조회
+const getCorrection = async () => {
+	const q = query(collection(db, 'WorkCorrections'), where('userId', '==', getUserId()));
+	const querySnapshot = await getDocs(q);
+	const docData = querySnapshot.docs.map((doc) => doc.data());
+	const workCorrections = docData.map((obj) => {
+		const workDate = new Date(obj.workDate.seconds * 1000);
+		const reqDate = new Date(obj.requestDate.seconds * 1000);
+		const newObj = {
+			workDate: `${workDate.getUTCFullYear()}-${workDate.getUTCMonth() + 1}-${workDate.getUTCDate()}`,
+			reqDate: `${reqDate.getUTCFullYear()}-${reqDate.getUTCMonth() + 1}-${reqDate.getUTCDate()}`,
+			workingTimes: obj.workingTimes,
+			type: obj.type,
+			approveStatus: obj.approveStatus,
+			description: obj.description,
+		};
+		return newObj;
+	});
+
+	return { workCorrections };
+};
+
+export default getCorrection;

--- a/src/api/work/getOfficialWage.ts
+++ b/src/api/work/getOfficialWage.ts
@@ -8,7 +8,7 @@ const getOfficialWage = async (year: number, month: number) => {
 	const endOfMonth = new Date(year, month, 0, 23, 59, 59);
 
 	const q = query(
-		collection(db, 'Officialschedules'),
+		collection(db, 'OfficialSchedules'),
 		where('userId', '==', getUserId()),
 		where('date', '>=', startOfMonth),
 		where('date', '<=', endOfMonth),

--- a/src/api/work/getPersonalWage.ts
+++ b/src/api/work/getPersonalWage.ts
@@ -1,6 +1,25 @@
-// 특정 달 개인 스케줄에 따른 예상 급여액 조회
-const getPersonalWage = async () => {
-	// 작성 예정
+import { db } from '@/firebaseConfig';
+import { collection, query, where, getDocs } from 'firebase/firestore';
+import getUserId from '@/api/common/getUserId';
+
+// 개인 스케줄에 따른 특정 달의 예상 급여액 조회
+const getPersonalWage = async (year: number, month: number) => {
+	const startOfMonth = new Date(year, month - 1, 1);
+	const endOfMonth = new Date(year, month, 0, 23, 59, 59);
+
+	const q = query(
+		collection(db, 'PersonalSchedules'),
+		where('userId', '==', getUserId()),
+		where('date', '>=', startOfMonth),
+		where('date', '<=', endOfMonth),
+	);
+	const querySnapshot = await getDocs(q);
+	const docData = querySnapshot.docs.map((doc) => doc.data());
+
+	return {
+		totalWorkHour: docData.length * 5,
+		totalWage: docData.length * 45135,
+	};
 };
 
 export default getPersonalWage;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

급여, 프로필 페이지에서 사용되는 API 구현

## 📋 작업 내용

- 특정 달의 개인 근무 일정에 따른 예상 급여액 관련 정보 조회 API 구현 (getPersonalWage)
- 근무 정정신청 API 구현 (createCorrection)
- 근무 정정신청 내역 조회 API 구현 (getCorrection)
- 로그인한 회원의 개인 정보 조회 API 구현 (getUserInfo)

## 🔧 변경 사항

위와 같습니다.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

- createCorrection의 경우에는 사용하는 입장에서 정정신청의 대상이 되는 근무일을 입력하게 되어 있는데, string 타입으로 'yyyy-mm-dd'의 형식으로 입력해주시면 됩니다.
