### PR TITLE
[feature] 일정표 페이지 API 구현

### DIFF
--- a/src/api/schedule/createPersonalSchedule.ts
+++ b/src/api/schedule/createPersonalSchedule.ts
@@ -1,1 +1,56 @@
-// 개인 근무 일정 생성
+import { db } from '@/firebaseConfig';
+import {
+	collection,
+	addDoc,
+	query,
+	where,
+	getDocs,
+	updateDoc,
+	arrayUnion,
+} from 'firebase/firestore';
+import getUserId from '@/api/common/getUserId';
+
+type TWorkingTimes = 'open' | 'middle' | 'close';
+
+// 개인 근무 일정 생성 API
+const createPersonalSchedule = async (
+	workDate: string,
+	workingTimes: TWorkingTimes,
+	memos: string,
+) => {
+	try {
+		const userId = getUserId();
+		const workDateObj = new Date(workDate);
+
+		const q = query(
+			collection(db, 'PersonalSchedules'),
+			where('userId', '==', userId),
+			where('date', '==', workDateObj),
+		);
+
+		const querySnapshot = await getDocs(q);
+
+		if (!querySnapshot.empty) {
+			// 데이터가 이미 존재할 경우 업데이트
+			const docRef = querySnapshot.docs[0].ref;
+			await updateDoc(docRef, {
+				workingTimes: arrayUnion(workingTimes),
+				memos: arrayUnion(memos),
+			});
+		} else {
+			// 데이터가 존재하지 않으면 새로 생성
+			await addDoc(collection(db, 'PersonalSchedules'), {
+				userId,
+				date: workDateObj,
+				workingTimes: [workingTimes],
+				memos: [memos],
+			});
+		}
+
+		return true;
+	} catch (error) {
+		return false;
+	}
+};
+
+export default createPersonalSchedule;

--- a/src/api/schedule/deletePersonalSchedule.ts
+++ b/src/api/schedule/deletePersonalSchedule.ts
@@ -1,1 +1,50 @@
-// 개인 근무 일정 삭제
+import { db } from '@/firebaseConfig';
+import { collection, query, where, getDocs, updateDoc, deleteDoc } from 'firebase/firestore';
+import getUserId from '@/api/common/getUserId';
+
+type TWorkingTimes = 'open' | 'middle' | 'close';
+
+// 개인 근무 일정 삭제 API
+const deletePersonalSchedule = async (workDate: string, workingTimes: TWorkingTimes) => {
+	try {
+		const userId = getUserId();
+		const workDateObj = new Date(workDate);
+
+		const q = query(
+			collection(db, 'PersonalSchedules'),
+			where('userId', '==', userId),
+			where('date', '==', workDateObj),
+		);
+
+		const querySnapshot = await getDocs(q);
+
+		querySnapshot.forEach(async (doc) => {
+			const data = doc.data();
+			const workingTimesArray = data.workingTimes || [];
+			const memosArray = data.memos || [];
+
+			const index = workingTimesArray.indexOf(workingTimes);
+			if (index > -1) {
+				workingTimesArray.splice(index, 1);
+				memosArray.splice(index, 1);
+
+				// 해당 데이터에 아무 값도 없을 경우 데이터 자체를 삭제
+				if (workingTimesArray.length === 0 && memosArray.length === 0) {
+					await deleteDoc(doc.ref);
+				} else {
+					// 만약 남아있는 값이 있다면 해당 값은 유지하도록 업데이트
+					await updateDoc(doc.ref, {
+						workingTimes: workingTimesArray,
+						memos: memosArray,
+					});
+				}
+			}
+		});
+
+		return true;
+	} catch (error) {
+		return false;
+	}
+};
+
+export default deletePersonalSchedule;

--- a/src/api/schedule/getOfficialSchedule.ts
+++ b/src/api/schedule/getOfficialSchedule.ts
@@ -2,7 +2,7 @@ import { db } from '@/firebaseConfig';
 import { collection, query, where, getDocs } from 'firebase/firestore';
 import getUserId from '@/api/common/getUserId';
 
-// 특정 달의 공식 근무 일정 조회
+// 특정 달의 공식 근무 일정 조회 API
 const getOfficialSchedule = async (year: number, month: number) => {
 	const startOfMonth = new Date(year, month - 1, 1);
 	const endOfMonth = new Date(year, month, 0, 23, 59, 59);

--- a/src/api/schedule/getPersonalSchedule.ts
+++ b/src/api/schedule/getPersonalSchedule.ts
@@ -1,1 +1,31 @@
-// 개인 근무 일정 조회
+import { db } from '@/firebaseConfig';
+import { collection, query, where, getDocs } from 'firebase/firestore';
+import getUserId from '@/api/common/getUserId';
+
+// 특정 달의 개인 근무 일정 조회 API
+const getPersonalSchedule = async (year: number, month: number) => {
+	const startOfMonth = new Date(year, month - 1, 1);
+	const endOfMonth = new Date(year, month, 0, 23, 59, 59);
+
+	const q = query(
+		collection(db, 'PersonalSchedules'),
+		where('userId', '==', getUserId()),
+		where('date', '>=', startOfMonth),
+		where('date', '<=', endOfMonth),
+	);
+	const querySnapshot = await getDocs(q);
+	const docData = querySnapshot.docs.map((doc) => doc.data());
+	const personalScheduleArray = docData.map((obj) => {
+		const date = new Date(obj.date.seconds * 1000);
+		const newObj = {
+			date: `${date.getUTCFullYear()}-${date.getUTCMonth() + 1}-${date.getUTCDate()}`,
+			workingTimes: obj.workingTimes,
+			memos: obj.memos,
+		};
+		return newObj;
+	});
+
+	return { personalScheduleData: personalScheduleArray };
+};
+
+export default getPersonalSchedule;

--- a/src/api/schedule/updatePersonalSchedule.ts
+++ b/src/api/schedule/updatePersonalSchedule.ts
@@ -1,1 +1,45 @@
-// 개인 근무 일정 수정
+import { db } from '@/firebaseConfig';
+import { collection, query, where, getDocs, updateDoc } from 'firebase/firestore';
+import getUserId from '@/api/common/getUserId';
+
+type TWorkingTimes = 'open' | 'middle' | 'close';
+
+// 개인 근무 일정 수정 API
+const updatePersonalSchedule = async (
+	workDate: string,
+	oldWorkingTimes: TWorkingTimes,
+	newWorkingTimes: TWorkingTimes,
+	memos: string,
+) => {
+	try {
+		const userId = getUserId();
+		const workDateObj = new Date(workDate);
+
+		const q = query(
+			collection(db, 'PersonalSchedules'),
+			where('userId', '==', userId),
+			where('date', '==', workDateObj),
+		);
+
+		const querySnapshot = await getDocs(q);
+		const docRef = querySnapshot.docs[0].ref;
+		const scheduleData = querySnapshot.docs[0].data();
+		const workingTimesIndex = scheduleData.workingTimes.indexOf(oldWorkingTimes);
+		const updatedWorkingTimes = [...scheduleData.workingTimes];
+		const updatedMemos = [...scheduleData.memos];
+
+		updatedWorkingTimes[workingTimesIndex] = newWorkingTimes;
+		updatedMemos[workingTimesIndex] = memos;
+
+		await updateDoc(docRef, {
+			workingTimes: updatedWorkingTimes,
+			memos: updatedMemos,
+		});
+
+		return true;
+	} catch (error) {
+		return false;
+	}
+};
+
+export default updatePersonalSchedule;

--- a/src/api/user/getUserInfo.ts
+++ b/src/api/user/getUserInfo.ts
@@ -2,7 +2,7 @@ import { db } from '@/firebaseConfig';
 import { collection, query, where, getDocs } from 'firebase/firestore';
 import getUserId from '@/api/common/getUserId';
 
-// 회원 정보 조회
+// 회원 정보 조회 API
 const getUserInfo = async () => {
 	const q = query(collection(db, 'User'), where('userId', '==', getUserId()));
 	const querySnapshot = await getDocs(q);

--- a/src/api/work/createCorrection.ts
+++ b/src/api/work/createCorrection.ts
@@ -5,7 +5,7 @@ import getUserId from '@/api/common/getUserId';
 type TWorkingTimes = 'open' | 'middle' | 'close';
 type TType = 'cover' | 'special' | 'vacation' | 'early';
 
-// 근무 정정신청
+// 근무 정정신청 API
 const createCorrection = async (
 	workDate: string,
 	workingTimes: TWorkingTimes,

--- a/src/api/work/getCorrection.ts
+++ b/src/api/work/getCorrection.ts
@@ -2,7 +2,7 @@ import { db } from '@/firebaseConfig';
 import { collection, query, where, getDocs } from 'firebase/firestore';
 import getUserId from '@/api/common/getUserId';
 
-// 근무 정정신청 내역 조회
+// 근무 정정신청 내역 조회 API
 const getCorrection = async () => {
 	const q = query(collection(db, 'WorkCorrections'), where('userId', '==', getUserId()));
 	const querySnapshot = await getDocs(q);

--- a/src/api/work/getOfficialWage.ts
+++ b/src/api/work/getOfficialWage.ts
@@ -2,7 +2,7 @@ import { db } from '@/firebaseConfig';
 import { collection, query, where, getDocs } from 'firebase/firestore';
 import getUserId from '@/api/common/getUserId';
 
-// 공식 스케줄에 따른 특정 달의 급여 내역 및 예상 급여액 조회
+// 공식 스케줄에 따른 특정 달의 급여 내역 및 예상 급여액 조회 API
 const getOfficialWage = async (year: number, month: number) => {
 	const startOfMonth = new Date(year, month - 1, 1);
 	const endOfMonth = new Date(year, month, 0, 23, 59, 59);

--- a/src/api/work/getPersonalWage.ts
+++ b/src/api/work/getPersonalWage.ts
@@ -2,7 +2,7 @@ import { db } from '@/firebaseConfig';
 import { collection, query, where, getDocs } from 'firebase/firestore';
 import getUserId from '@/api/common/getUserId';
 
-// 개인 스케줄에 따른 특정 달의 예상 급여액 조회
+// 개인 스케줄에 따른 특정 달의 예상 급여액 조회 API
 const getPersonalWage = async (year: number, month: number) => {
 	const startOfMonth = new Date(year, month - 1, 1);
 	const endOfMonth = new Date(year, month, 0, 23, 59, 59);


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

일정표 페이지에서 사용되는 API 구현

## 📋 작업 내용

- 특정 달의 개인 근무 일정 정보 조회 API 구현 (getPersonalSchedule)
- 특정 달의 개인 근무 일정 정보 추가 API 구현 (createPersonalSchedule)
- 특정 달의 개인 근무 일정 정보 수정 API 구현 (updatePersonalSchedule)
- 특정 달의 개인 근무 일정 정보 삭제 API 구현 (deletePersonalSchedule)
- 그 외 API 주석 양식 통일 처리했습니다.

## 🔧 변경 사항

위와 같습니다.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

- 개인 근무 일정 수정(updatePersonalSchedule) 로직의 경우에 다른 처리와 다르게 값을 수정하다 보니, 수정 대상이 되는 근무 시간대(open, middle 등) 값이 필요해서 매개 변수로 oldWorkingTimes(이전 값), newWorkingTimes(변경 값)을 받도록 했습니다.
**쉽게 말해 오픈 시간대로 설정된 일정을 수정해 미들 시간으로 변경한다면, oldWorkingTimes = 'open', newWorkingTimes = 'middle' 값이 필요합니다.**
