### PR TITLE
[feature] 회원 정보 Redux 전역 상태 관리

### DIFF
--- a/src/api/user/getUserInfo.ts
+++ b/src/api/user/getUserInfo.ts
@@ -3,7 +3,11 @@ import { collection, query, where, getDocs } from 'firebase/firestore';
 import getUserId from '@/api/common/getUserId';
 
 // 회원 정보 조회 API
-const getUserInfo = async () => {
+const getUserInfo = async (): Promise<{
+	name: string;
+	workPlace: string;
+	workingSets: { times: []; weeks: [] };
+}> => {
 	const q = query(collection(db, 'User'), where('userId', '==', getUserId()));
 	const querySnapshot = await getDocs(q);
 	const docData = querySnapshot.docs.map((doc) => doc.data());
@@ -16,9 +20,7 @@ const getUserInfo = async () => {
 		return newObj;
 	});
 
-	return {
-		userInfo: userInfoData[0],
-	};
+	return userInfoData[0];
 };
 
 export default getUserInfo;

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,30 +1,23 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchUserInfo, clearUserInfo } from '@/stores/userInfoSlice';
+import { AppDispatch, RootState } from '@/stores/store';
+import { useEffect } from 'react';
 import ProfileMenu from '@/components/Profile/ProfileMenu';
 import UserProfile from '@/components/Profile/UserProfile';
-import getUserInfo from '@/api/user/getUserInfo';
-import { useEffect, useState } from 'react';
-
-interface IUserInfo {
-	name: string;
-	workPlace: string;
-	workingSets: { times: string[]; weeks: string[] };
-}
 
 const Profile = () => {
-	const [userInfo, setUserInfo] = useState<IUserInfo | null>(null);
-	const [error, setError] = useState<string | null>(null);
-
-	const fetchUserInfo = async () => {
-		try {
-			const data = await getUserInfo();
-			setUserInfo(data.userInfo);
-		} catch (error) {
-			setError('Failed to fetch user info');
-		}
-	};
+	const dispatch: AppDispatch = useDispatch();
+	const { name, workPlace, workingSets, loading, error } = useSelector(
+		(state: RootState) => state.userInfo,
+	);
 
 	useEffect(() => {
-		fetchUserInfo();
-	}, []);
+		dispatch(fetchUserInfo());
+
+		return () => {
+			dispatch(clearUserInfo());
+		};
+	}, [dispatch]);
 
 	return (
 		<>
@@ -33,9 +26,9 @@ const Profile = () => {
 			) : (
 				<>
 					<UserProfile
-						workPlace={userInfo?.workPlace || '근무지 없음'}
-						name={userInfo?.name || '미정'}
-						workTime={userInfo?.workingSets || { times: [], weeks: [] }}
+						workPlace={workPlace || '근무지 없음'}
+						name={name || '미정'}
+						workTime={workingSets || { times: [], weeks: [] }}
 					/>
 					<ProfileMenu />
 				</>

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1,14 +1,17 @@
 import { configureStore } from '@reduxjs/toolkit';
 import modalReducer, { IModalState } from '@/stores/modalSlice';
+import userInfoReducer, { IUserInfoState } from '@/stores/userInfoSlice';
 
 const store = configureStore({
 	reducer: {
 		modal: modalReducer,
+		userInfo: userInfoReducer,
 	},
 });
 
 export type RootState = {
 	modal: IModalState;
+	userInfo: IUserInfoState;
 };
 export type AppDispatch = typeof store.dispatch;
 

--- a/src/stores/userInfoSlice.ts
+++ b/src/stores/userInfoSlice.ts
@@ -1,0 +1,67 @@
+import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
+import getUserInfo from '@/api/user/getUserInfo';
+
+interface IUserInfo {
+	name: string;
+	workPlace: string;
+	workingSets: { times: []; weeks: [] };
+}
+
+export interface IUserInfoState extends IUserInfo {
+	loading: boolean;
+	error: string | null;
+}
+
+const initialState: IUserInfoState = {
+	name: '',
+	workPlace: '',
+	workingSets: { times: [], weeks: [] },
+	loading: false,
+	error: null,
+};
+
+export const fetchUserInfo = createAsyncThunk<IUserInfo, void, { rejectValue: string }>(
+	'userInfo/fetchUserInfo',
+	async (_, thunkAPI) => {
+		try {
+			const userInfo = await getUserInfo();
+			return userInfo as IUserInfo;
+		} catch (error: any) {
+			return thunkAPI.rejectWithValue(error.message);
+		}
+	},
+);
+
+const userInfoSlice = createSlice({
+	name: 'userInfo',
+	initialState,
+	reducers: {
+		clearUserInfo: (state) => {
+			state.name = '';
+			state.workPlace = '';
+			state.workingSets = { times: [], weeks: [] };
+			state.loading = false;
+			state.error = null;
+		},
+	},
+	extraReducers: (builder) => {
+		builder
+			.addCase(fetchUserInfo.pending, (state) => {
+				state.loading = true;
+				state.error = null;
+			})
+			.addCase(fetchUserInfo.fulfilled, (state, action: PayloadAction<IUserInfo>) => {
+				state.name = action.payload.name;
+				state.workPlace = action.payload.workPlace;
+				state.workingSets = action.payload.workingSets;
+				state.loading = false;
+			})
+			.addCase(fetchUserInfo.rejected, (state, action: PayloadAction<string | undefined>) => {
+				state.loading = false;
+				state.error = action.payload ?? 'Unknown error';
+			});
+	},
+});
+
+export const { clearUserInfo } = userInfoSlice.actions;
+export default userInfoSlice.reducer;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

회원 정보 Redux 전역 상태 관리 및 프로필 페이지 적용

## 📋 작업 내용

- 회원 정보 관리를 위한 Redux 관련 파일(userInfoSlice)을 생성하고 기존에 존재하던 store와 연동했습니다.
- 기존 프로필 페이지에서 API를 이용해 가져오던 회원 정보를 Redux 전역 상태를 통해 관리하도록 수정했습니다.

## 🔧 변경 사항

위와 같습니다.

## 📸 스크린샷 (선택 사항)

![Component 1](https://github.com/user-attachments/assets/422fcb04-9ffa-42f3-adea-672d241f2ac4)

- 로그인한 사용자가 정보가 Redux에서 관리되며, 문제 없이 렌더링됩니다.

## 📄 기타

- 아직 리덕스 이해도가 높은 편이 아니라 최대한 예제 코드를 보면서 작성했습니다. 추후에 수정될 수 있음!