### PR TITLE
[feat] 정정 신청 내역 페이지 구현(필터링, 더보기 기능) 

### DIFF
--- a/src/components/Wage/ApprovedStatusBadge.tsx
+++ b/src/components/Wage/ApprovedStatusBadge.tsx
@@ -1,0 +1,63 @@
+import { FC } from 'react';
+import styled from '@emotion/styled';
+import { fontSize } from '@/constants/font';
+import { badgeColors } from '@/constants/badgeColors';
+import { colors } from '@/constants/colors';
+
+export interface IApprovedStatusBadgeProps {
+	approvedStatus: string;
+}
+
+const ApprovedStatusBadge: FC<IApprovedStatusBadgeProps> = ({ approvedStatus }) => {
+	const badgeType = approvedStatus;
+	const Badge =
+		BadgeContainer[badgeType as keyof typeof BadgeContainer] || BadgeContainer.default;
+
+	const workTypeLabels: { [key: string]: string } = {
+		pending: '대기',
+		approved: '승인',
+		rejected: '반려',
+	};
+
+	return <Badge>{workTypeLabels[badgeType]}</Badge>;
+};
+
+export default ApprovedStatusBadge;
+
+const BaseBadge = styled.span`
+	width: 50px;
+	padding: 4px 16px;
+	border-radius: 4px;
+	font-size: ${fontSize.sm};
+`;
+
+const BadgeContainer = {
+	pending: styled(BaseBadge)`
+		background-color: ${badgeColors.nightGreen};
+		color: ${colors.black};
+		svg {
+			color: ${colors.nightGreen};
+		}
+	`,
+	approved: styled(BaseBadge)`
+		background-color: ${badgeColors.primaryYellow};
+		color: ${colors.black};
+		svg {
+			color: ${colors.primaryYellow};
+		}
+	`,
+	rejected: styled(BaseBadge)`
+		background-color: ${badgeColors.afternoonPink};
+		color: ${colors.black};
+		svg {
+			color: ${colors.afternoonPink};
+		}
+	`,
+	default: styled(BaseBadge)`
+		background-color: ${colors.veryLightGray};
+		color: ${colors.black};
+		svg {
+			color: ${colors.black};
+		}
+	`,
+};

--- a/src/components/Wage/CorrectionTable.tsx
+++ b/src/components/Wage/CorrectionTable.tsx
@@ -1,0 +1,160 @@
+// TODO: 목데이터로 적용중, 추후 파이어베이스로 변경 예정
+// import getCorrection from '@/api/work/getCorrection';
+import { useEffect, useState } from 'react';
+import styled from '@emotion/styled';
+import { colors } from '@/constants/colors';
+import ApprovedStatusBadge from './ApprovedStatusBadge';
+import { useNavigate } from 'react-router-dom';
+import mockData from '@/data/correctionMockData.json';
+import { getApprovedStatusLabel, getWorkTypeLabel } from '@/utils/labelUtils';
+import Button from '../common/Button/Button';
+
+// TODO: 추후 타입 좁힐 예정임.
+// type TApproveStatus = 'pending' | 'approved' | 'rejected';
+// type TType = 'cover' | 'special' | 'vacation' | 'early';
+// type TWorkingTimes = 'open' | 'middle' | 'close';
+
+// interface ICorrectionItem {
+// 	approveStatus: TApproveStatus;
+// 	description: string;
+// 	reqDate: string;
+// 	type: TType;
+// 	workDate: string;
+// 	workingTimes: TWorkingTimes;
+// }
+
+interface ICorrectionItem {
+	approveStatus: string;
+	description: string;
+	reqDate: string;
+	type: string;
+	workDate: string;
+	workingTimes: string;
+}
+
+interface ICorrectionTableProps {
+	approvedFilter?: string;
+	typeFilter?: string;
+}
+
+export const CorrectionTable = ({ approvedFilter, typeFilter }: ICorrectionTableProps) => {
+	const columns = ['요청날짜', '근무정정 유형', '승인상태'];
+	const [corrections, setCorrections] = useState<ICorrectionItem[]>([]);
+	const [visibleItems, setVisibleItems] = useState(10);
+	const navigate = useNavigate();
+
+	const handleCorrection = (index: number) => () => {
+		navigate(`/wage/correction/${index}`);
+	};
+
+	const formatDate = (dateStr: string): string => {
+		const date = new Date(dateStr);
+		return date.toLocaleDateString('en-CA');
+	};
+
+	const fetchCorrection = async () => {
+		// TODO: 목데이터로 적용중, 추후 파이어베이스로 변경 예정
+		// const data = await getCorrection();
+		const filteredCorrections = mockData.workCorrections
+			.filter((correction) => {
+				return (
+					(!approvedFilter ||
+						getApprovedStatusLabel(correction.approveStatus) === approvedFilter) &&
+					(!typeFilter || getWorkTypeLabel(correction.type) === typeFilter)
+				);
+			})
+			.map((correction: ICorrectionItem) => ({
+				...correction,
+				reqDate: formatDate(correction.reqDate),
+				workDate: formatDate(correction.workDate),
+			}));
+
+		setCorrections(filteredCorrections);
+	};
+
+	const handleLoadMore = () => {
+		setVisibleItems((prev) => prev + 5);
+	};
+
+	useEffect(() => {
+		fetchCorrection();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [approvedFilter, typeFilter]);
+	return (
+		<TableContainer>
+			<thead>
+				<tr>
+					{columns.map((column) => (
+						<th key={column}>{column}</th>
+					))}
+				</tr>
+			</thead>
+			<tbody>
+				{corrections.slice(0, visibleItems).map((correction, index) => {
+					const workLabel = getWorkTypeLabel(correction.type);
+
+					return (
+						<tr key={index} onClick={handleCorrection(index + 1)}>
+							<td>{correction.reqDate}</td>
+							<td>{workLabel}</td>
+							<td>
+								{' '}
+								<ApprovedStatusBadge
+									approvedStatus={correction.approveStatus}
+								></ApprovedStatusBadge>{' '}
+							</td>
+						</tr>
+					);
+				})}
+			</tbody>
+
+			{visibleItems < corrections.length && (
+				<tfoot>
+					<tr>
+						<td colSpan={3}>
+							<Button
+								label="더보기"
+								onClick={handleLoadMore}
+								size="normal"
+								theme="secondary"
+								buttonWidth="calc(100% - 40px)"
+							/>
+						</td>
+					</tr>
+				</tfoot>
+			)}
+		</TableContainer>
+	);
+};
+
+export default CorrectionTable;
+
+const TableContainer = styled.table`
+	width: 100%;
+	margin-bottom: 80px;
+
+	thead {
+		height: 60px;
+		background-color: ${colors.lightestGray};
+		border-top: 1px solid ${colors.lightGray};
+		border-bottom: 1px solid ${colors.lightGray};
+		th {
+			width: calc(100% / 3);
+		}
+	}
+	tbody {
+		td {
+			width: calc(100% / 3);
+			height: 60px;
+			text-align: center;
+			cursor: pointer;
+		}
+	}
+
+	tfoot {
+		text-align: center;
+		button {
+			margin-top: 10px;
+		}
+	}
+`;

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,6 +1,8 @@
+// TODO: 하나의 드롭다운만 열리고, 다른 드롭다운을 열면 이전에 열린 드롭다운이 자동 닫히는 기능 만들 예정
 import React, { useState, useCallback } from 'react';
 import styled from '@emotion/styled';
 import { colors } from '@/constants/colors';
+import { ChevronDown } from 'lucide-react';
 
 interface IDropdownProps {
 	options: { value: string; label: string; color?: string }[];
@@ -8,6 +10,7 @@ interface IDropdownProps {
 	onSelect: (option: string) => void;
 	disabled?: boolean;
 	className?: string;
+	defaultLabel: string;
 }
 
 const Dropdown: React.FC<IDropdownProps> = ({
@@ -16,6 +19,7 @@ const Dropdown: React.FC<IDropdownProps> = ({
 	onSelect,
 	disabled,
 	className,
+	defaultLabel,
 }) => {
 	const [isOpen, setIsOpen] = useState(false);
 
@@ -40,8 +44,11 @@ const Dropdown: React.FC<IDropdownProps> = ({
 	return (
 		<DropdownContainer className={className}>
 			<DropdownButton onClick={handleToggle} disabled={disabled} className={className}>
-				{selectedOptionData?.color && <ColorCircle color={selectedOptionData.color} />}
-				{selectedOptionData?.label || '선택'}
+				<div>
+					{selectedOptionData?.color && <ColorCircle color={selectedOptionData.color} />}
+					{selectedOptionData?.label || <span>{defaultLabel}</span>}
+				</div>
+				<ChevronDown />
 			</DropdownButton>
 			{isOpen && (
 				<DropdownMenu>
@@ -65,8 +72,12 @@ const DropdownContainer = styled.div`
 `;
 
 const DropdownButton = styled.button<{ disabled?: boolean }>`
-	width: 100%;
 	padding: 8px;
+	width: 100%;
+	height: 44px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
 	border: ${(props) => (props.disabled ? 'none' : `1px solid ${colors.lightGray}`)};
 	border-radius: 8px;
 	background-color: ${(props) => (props.disabled ? colors.lightestGray : colors.white)};
@@ -76,13 +87,7 @@ const DropdownButton = styled.button<{ disabled?: boolean }>`
 	appearance: none;
 	-webkit-appearance: none;
 	-moz-appearance: none;
-	height: 44px;
-	display: flex;
-	align-items: center;
-	&:after {
-		content: '▼';
-		margin-left: auto;
-	}
+
 	&.error {
 		border: 1px solid ${colors.red};
 	}
@@ -108,7 +113,7 @@ const DropdownItem = styled.li`
 	display: flex;
 	align-items: center;
 	&:hover {
-		background-color: ${colors.lightGray};
+		background-color: ${colors.lightestGray};
 	}
 `;
 

--- a/src/components/common/Title.tsx
+++ b/src/components/common/Title.tsx
@@ -1,0 +1,34 @@
+import { FC, ReactNode } from 'react';
+import styled from '@emotion/styled';
+import { fontSize, fontWeight } from '@/constants/font';
+
+interface ITitleProps {
+	title: string;
+	onClick?: () => void;
+	className?: string;
+	element?: ReactNode;
+}
+
+const Title: FC<ITitleProps> = ({ title, className, element }) => {
+	return (
+		<TitleContainer className={className}>
+			<h2>{title}</h2>
+			{element}
+		</TitleContainer>
+	);
+};
+
+export default Title;
+
+const TitleContainer = styled.div`
+	padding-left: 20px;
+	padding-right: 20px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+
+	h2 {
+		font-size: ${fontSize.xl};
+		font-weight: ${fontWeight.bold};
+	}
+`;

--- a/src/data/correctionMockData.json
+++ b/src/data/correctionMockData.json
@@ -1,0 +1,164 @@
+{
+	"workCorrections": [
+		{
+			"approveStatus": "approved",
+			"description": "Routine cover for vacation",
+			"reqDate": "2024-7-1",
+			"type": "cover",
+			"workDate": "2024-7-2",
+			"workingTimes": "open"
+		},
+		{
+			"approveStatus": "rejected",
+			"description": "Emergency cover needed",
+			"reqDate": "2024-7-3",
+			"type": "cover",
+			"workDate": "2024-7-4",
+			"workingTimes": "middle"
+		},
+		{
+			"approveStatus": "pending",
+			"description": "Special project work",
+			"reqDate": "2024-7-5",
+			"type": "special",
+			"workDate": "2024-7-6",
+			"workingTimes": "close"
+		},
+		{
+			"approveStatus": "approved",
+			"description": "Vacation leave scheduled",
+			"reqDate": "2024-7-7",
+			"type": "vacation",
+			"workDate": "2024-7-8",
+			"workingTimes": "open"
+		},
+		{
+			"approveStatus": "rejected",
+			"description": "Early leave for medical appointment",
+			"reqDate": "2024-7-9",
+			"type": "early",
+			"workDate": "2024-7-10",
+			"workingTimes": "middle"
+		},
+		{
+			"approveStatus": "approved",
+			"description": "Vacation leave",
+			"reqDate": "2024-7-11",
+			"type": "vacation",
+			"workDate": "2024-7-12",
+			"workingTimes": "close"
+		},
+		{
+			"approveStatus": "pending",
+			"description": "Cover for sick leave",
+			"reqDate": "2024-7-13",
+			"type": "cover",
+			"workDate": "2024-7-14",
+			"workingTimes": "open"
+		},
+		{
+			"approveStatus": "rejected",
+			"description": "Special event participation",
+			"reqDate": "2024-7-15",
+			"type": "special",
+			"workDate": "2024-7-16",
+			"workingTimes": "middle"
+		},
+		{
+			"approveStatus": "approved",
+			"description": "Special training session",
+			"reqDate": "2024-7-17",
+			"type": "special",
+			"workDate": "2024-7-18",
+			"workingTimes": "close"
+		},
+		{
+			"approveStatus": "rejected",
+			"description": "Early dismissal requested",
+			"reqDate": "2024-7-19",
+			"type": "early",
+			"workDate": "2024-7-20",
+			"workingTimes": "open"
+		},
+		{
+			"approveStatus": "pending",
+			"description": "Cover for conference",
+			"reqDate": "2024-7-21",
+			"type": "cover",
+			"workDate": "2024-7-22",
+			"workingTimes": "middle"
+		},
+		{
+			"approveStatus": "approved",
+			"description": "Vacation leave approved",
+			"reqDate": "2024-7-23",
+			"type": "vacation",
+			"workDate": "2024-7-24",
+			"workingTimes": "close"
+		},
+		{
+			"approveStatus": "rejected",
+			"description": "Unexpected early leave",
+			"reqDate": "2024-7-25",
+			"type": "early",
+			"workDate": "2024-7-26",
+			"workingTimes": "open"
+		},
+		{
+			"approveStatus": "approved",
+			"description": "Training day",
+			"reqDate": "2024-7-27",
+			"type": "special",
+			"workDate": "2024-7-28",
+			"workingTimes": "middle"
+		},
+		{
+			"approveStatus": "pending",
+			"description": "Requested vacation day",
+			"reqDate": "2024-7-29",
+			"type": "vacation",
+			"workDate": "2024-7-30",
+			"workingTimes": "close"
+		},
+		{
+			"approveStatus": "rejected",
+			"description": "Special duty on project",
+			"reqDate": "2024-7-31",
+			"type": "special",
+			"workDate": "2024-8-1",
+			"workingTimes": "open"
+		},
+		{
+			"approveStatus": "approved",
+			"description": "Early leave for personal reasons",
+			"reqDate": "2024-8-2",
+			"type": "early",
+			"workDate": "2024-8-3",
+			"workingTimes": "middle"
+		},
+		{
+			"approveStatus": "pending",
+			"description": "Vacation leave request",
+			"reqDate": "2024-8-4",
+			"type": "vacation",
+			"workDate": "2024-8-5",
+			"workingTimes": "close"
+		},
+		{
+			"approveStatus": "approved",
+			"description": "Cover required for absent colleague",
+			"reqDate": "2024-8-6",
+			"type": "cover",
+			"workDate": "2024-8-7",
+			"workingTimes": "open"
+		},
+		{
+			"approveStatus": "rejected",
+			"description": "Special work on a holiday",
+			"reqDate": "2024-8-8",
+			"type": "special",
+			"workDate": "2024-8-9",
+			"workingTimes": "middle"
+		}
+	]
+}

--- a/src/pages/Wage/Correction/Correction.tsx
+++ b/src/pages/Wage/Correction/Correction.tsx
@@ -1,21 +1,92 @@
-import { Link } from 'react-router-dom';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/common/Button/Button';
+import Title from '@/components/common/Title';
+import styled from '@emotion/styled';
+import { colors } from '@/constants/colors';
+import Dropdown from '@/components/common/Dropdown';
+import CorrectionTable from '@/components/Wage/CorrectionTable';
+import { getApprovedStatusLabel, getWorkTypeLabel } from '@/utils/labelUtils';
 
 const Correction = () => {
-	const corrections = [1, 2, 3, 4, 7];
+	const [correctionType, setCorrectionType] = useState('');
+	const [approvedStatus, setApprovedStatus] = useState('');
+	const navigate = useNavigate();
+
+	const handleCorrection = () => {
+		navigate('/wage/correction/create');
+	};
+
 	return (
-		<>
-			<div>
-				<Link to="/wage/correction/create">정정 신청하기</Link>
+		<Container>
+			<Title
+				title="정정신청 내역"
+				element={
+					<Button
+						label="근무정정 신청"
+						onClick={handleCorrection}
+						size="small"
+						buttonWidth="110px"
+					/>
+				}
+				className="title border"
+			/>
+			<div className="dropdown-container border">
+				<Dropdown
+					defaultLabel="근무정정 유형"
+					options={[
+						{ value: '대타근무', label: '대타근무' },
+						{ value: '특별근무', label: '특별근무' },
+						{ value: '휴가', label: '휴가' },
+						{ value: '조퇴', label: '조퇴' },
+					]}
+					selectedOption={getWorkTypeLabel(correctionType)}
+					onSelect={setCorrectionType}
+					className="small-dropdown correction"
+				/>
+				<Dropdown
+					defaultLabel="승인상태"
+					options={[
+						{ value: '대기', label: '대기' },
+						{ value: '승인', label: '승인' },
+						{ value: '반려', label: '반려' },
+					]}
+					selectedOption={getApprovedStatusLabel(approvedStatus)}
+					onSelect={setApprovedStatus}
+					className="small-dropdown approved"
+				/>
 			</div>
-			<ul>
-				{corrections.map((id) => (
-					<li key={id}>
-						<Link to={`${id}`}>Correction Detail {id}</Link>
-					</li>
-				))}
-			</ul>
-		</>
+			<CorrectionTable approvedFilter={approvedStatus} typeFilter={correctionType} />
+		</Container>
 	);
 };
 
 export default Correction;
+
+const Container = styled.div`
+	.title {
+		padding-top: 20px;
+		padding-bottom: 16px;
+	}
+	.border {
+		border-bottom: 1px solid ${colors.lightestGray};
+	}
+	.dropdown-container {
+		padding: 10px 20px;
+		display: flex;
+		gap: 8px;
+		.small-dropdown.approved {
+			width: 100px;
+		}
+		.small-dropdown.correction {
+			width: 130px;
+		}
+		.small-dropdown {
+			height: 38px;
+		}
+
+		button.small-dropdown {
+			padding-left: 12px;
+		}
+	}
+`;

--- a/src/utils/labelUtils.ts
+++ b/src/utils/labelUtils.ts
@@ -1,0 +1,20 @@
+const workTypeLabels: { [key: string]: string } = {
+	cover: '대타근무',
+	special: '특별근무',
+	vacation: '휴가',
+	early: '조퇴',
+};
+
+export const getWorkTypeLabel = (type: string) => {
+	return workTypeLabels[type] || type;
+};
+
+const approvedStatusLabels: { [key: string]: string } = {
+	pending: '대기',
+	approved: '승인',
+	rejected: '반려',
+};
+
+export const getApprovedStatusLabel = (type: string) => {
+	return approvedStatusLabels[type] || type;
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**정정 신청 내역 페이지 구현(필터링, 더보기 기능)**

## 📋 작업 내용

정정 신청 내역 페이지 구현(필터링, 더보기 기능)

## 🔧 변경 사항

정정 신청 내역 페이지 구현(필터링, 더보기 기능)

## 📸 스크린샷 (선택 사항)

<img width="1448" alt="스크린샷 2024-08-06 오후 4 08 38" src="https://github.com/user-attachments/assets/5ff7a1b3-8f43-4ab5-93ca-8505ddeed330">


## 📄 기타
Dropdown파일에서 defaultLabel추가 해놓음. 그리고 호버색상 변경.
여기서 앞으로 해야될 일은 '하나의 드롭다운만 열리고, 다른 드롭다운을 열면 이전에 열린 드롭다운이 자동 닫히는 기능' 만들 예정임.

// TODO: 앞으로 해야되는 일들을 해놓음
할일이 많네요?ㅋㅋㅋㅋㅋㅋ 페이지 구현이 우선이라 뒤로 제쳐 둠

