### PR TITLE
[feature] 일정 수정 삭제 추가 기능 완료

### DIFF
--- a/src/components/SheduleModal/ScheduleModal.tsx
+++ b/src/components/SheduleModal/ScheduleModal.tsx
@@ -2,14 +2,14 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@/stores/store';
 import { closeModal, openModal } from '@/stores/modalSlice';
-import { addSchedule, deleteSchedule, scheduleData, updateSchedule } from '@/data/mockdata';
 import ModalOverlay from '@/components/common/Modal/ModalOverlay';
 import ModalFormComponent from '@/components/SheduleModal/ScheduleModalForm';
 import ModalFooterComponent from '@/components/SheduleModal/ScheduleModalFooter';
 import ModalContent from '@/components/common/Modal/ModalContent';
 import ModalHeaderComponent from '@/components/common/Modal/ModalHeader';
-
-type ModalContentType = 'add' | 'edit' | 'view' | null;
+import createPersonalSchedule from '@/api/schedule/createPersonalSchedule';
+import updatePersonalSchedule from '@/api/schedule/updatePersonalSchedule';
+import deletePersonalSchedule from '@/api/schedule/deletePersonalSchedule';
 
 interface ISchedule {
 	userId: string;
@@ -17,120 +17,169 @@ interface ISchedule {
 	wage: string;
 	workTime: string;
 	breakTime: string;
-	memo: string;
+	memos: string[];
 }
+const DEFAULT_WAGE = '10,030원';
+const WORK_TIME_OPTIONS = [
+	'선택',
+	'오픈 (07:00~12:00)',
+	'미들 (12:00~17:00)',
+	'마감 (17:00~22:00)',
+];
 
-const ScheduleModal: React.FC = () => {
+const DEFAULT_WORK_TIME = WORK_TIME_OPTIONS[0];
+const DEFAULT_BREAK_TIME = '30분';
+
+type TWorkingTimes = 'open' | 'middle' | 'close';
+
+const validateFields = (fields: { [key: string]: string }) => {
+	const errors: { [key: string]: boolean } = {};
+	Object.keys(fields).forEach((key) => {
+		if (!fields[key] || (key === 'workTime' && fields[key] === DEFAULT_WORK_TIME)) {
+			errors[key] = true;
+		}
+	});
+	return errors;
+};
+
+const ScheduleModal: React.FC<{ schedules: ISchedule[]; selectedSchedule: ISchedule | null }> = ({
+	schedules = [],
+	selectedSchedule,
+}) => {
 	const dispatch = useDispatch();
-	const { isOpen, content } = useSelector(
-		(state: RootState) => state.modal as { isOpen: boolean; content: ModalContentType },
-	);
+	const { isOpen, content } = useSelector((state: RootState) => state.modal);
 
 	const today = useMemo(() => new Date().toISOString().split('T')[0], []);
-	const defaultWage = useMemo(() => scheduleData[0].wage, []);
-	const defaultWorkTime = '';
-	const defaultMemo = '';
+	const defaultMemo = useMemo(
+		() => (schedules.length > 0 && schedules[0].memos.length > 0 ? schedules[0].memos[0] : ''),
+		[schedules],
+	);
 
 	const [workDate, setWorkDate] = useState(today);
-	const [wage, setWage] = useState(defaultWage);
-	const [workTime, setWorkTime] = useState(defaultWorkTime);
-	const [breakTime, setBreakTime] = useState('30분');
+	const [wage, setWage] = useState(DEFAULT_WAGE);
+	const [workTime, setWorkTime] = useState(DEFAULT_WORK_TIME);
+	const [breakTime, setBreakTime] = useState(DEFAULT_BREAK_TIME);
 	const [memo, setMemo] = useState(defaultMemo);
 	const [errors, setErrors] = useState<{ [key: string]: boolean }>({});
 
-	const resetForm = useCallback(() => {
-		setWorkDate(today);
-		setWage(defaultWage);
-		setWorkTime(defaultWorkTime);
-		setBreakTime('30분');
-		setMemo(defaultMemo);
-		setErrors({});
-	}, [today, defaultWage, defaultWorkTime, defaultMemo]);
+	const resetForm = useCallback(
+		(schedule: ISchedule | null = null) => {
+			if (schedule) {
+				const formattedDate = new Date(schedule.workDate).toISOString().split('T')[0];
+				setWorkDate(formattedDate);
+			} else {
+				const formattedDate = new Date(today).toISOString().split('T')[0];
+				setWorkDate(formattedDate);
+			}
+			setWage(DEFAULT_WAGE);
+			setWorkTime(DEFAULT_WORK_TIME);
+			setBreakTime(DEFAULT_BREAK_TIME);
+			setMemo('');
+			setErrors({});
+		},
+		[today],
+	);
 
 	const setFormValues = useCallback((schedule: ISchedule) => {
-		setWorkDate(schedule.workDate);
-		setWage(schedule.wage);
+		const formattedDate = new Date(schedule.workDate).toISOString().split('T')[0];
+		setWorkDate(formattedDate);
+		setWage(DEFAULT_WAGE);
 		setWorkTime(schedule.workTime);
-		setBreakTime(schedule.breakTime);
-		setMemo(schedule.memo);
+		setBreakTime(DEFAULT_BREAK_TIME);
+		setMemo(schedule.memos[0]); // 기존 스케줄의 메모 사용
 		setErrors({});
 	}, []);
 
 	useEffect(() => {
-		if (content === 'add') {
-			resetForm();
-		} else if (content === 'edit' || content === 'view') {
-			const schedule = scheduleData.find((s) => s.userId === '1'); // userId를 실제 값으로 변경 필요
-			if (schedule) {
-				setFormValues(schedule);
-			}
+		if (content === 'add' && schedules.length > 0) {
+			resetForm(schedules[0]);
+			setTimeout(() => setWorkTime(DEFAULT_WORK_TIME), 0);
+		} else if (selectedSchedule) {
+			setFormValues(selectedSchedule);
 		}
-	}, [content, resetForm, setFormValues]);
+	}, [content, resetForm, setFormValues, schedules, selectedSchedule]);
 
 	const handleOverlayClick = useCallback(
 		(e: React.MouseEvent) => {
 			if (e.target === e.currentTarget) {
 				dispatch(closeModal());
+				resetForm();
 			}
 		},
-		[dispatch],
+		[dispatch, resetForm],
 	);
 
-	const isFieldDisabled = useCallback(
-		(field: string): boolean => {
-			if (content === 'view') return true;
-			if (content === 'add' || content === 'edit') {
-				if (field === 'workTime' || field === 'memo') return false;
-			}
-			return true;
-		},
-		[content],
-	);
+	const isFieldDisabled = useCallback((): boolean => content === 'view', [content]);
 
-	const validateFields = useCallback(() => {
-		const newErrors: { [key: string]: boolean } = {};
-		if (!workDate) newErrors.workDate = true;
-		if (!wage) newErrors.wage = true;
-		if (!workTime) newErrors.workTime = true;
-		if (!breakTime) newErrors.breakTime = true;
-		if (!memo) newErrors.memo = true;
+	const convertWorkTimeForFirestore = (workTime: string): TWorkingTimes => {
+		switch (workTime) {
+			case '오픈 (07:00~12:00)':
+				return 'open';
+			case '미들 (12:00~17:00)':
+				return 'middle';
+			case '마감 (17:00~22:00)':
+				return 'close';
+			default:
+				throw new Error('Invalid work time');
+		}
+	};
+
+	const handleSave = useCallback(async () => {
+		const fields = { workDate, wage, workTime, breakTime, memo };
+		const newErrors = validateFields(fields);
 		setErrors(newErrors);
 
-		const errorFields = Object.keys(newErrors);
-		if (errorFields.length > 0) {
-			const firstErrorElement = document.querySelector(`.${errorFields[0]}`) as
-				| HTMLInputElement
-				| HTMLTextAreaElement;
-			firstErrorElement?.focus();
-		}
-
-		return errorFields.length === 0;
-	}, [workDate, wage, workTime, breakTime, memo]);
-
-	const handleSave = useCallback(() => {
-		if (validateFields()) {
-			if (content === 'edit') {
-				updateSchedule('1', { workDate, wage, workTime, breakTime, memo });
-			} else {
-				addSchedule({ workDate, wage, workTime, breakTime, memo });
-			}
-			dispatch(closeModal());
-		}
-	}, [validateFields, content, workDate, wage, workTime, breakTime, memo, dispatch]);
-
-	const handleDelete = useCallback(() => {
-		const scheduleIndex = scheduleData.findIndex((s) => s.userId === '1'); // userId를 실제 값으로 변경 필요
-		if (scheduleIndex !== -1) {
-			deleteSchedule(scheduleData[scheduleIndex].userId);
-			dispatch(closeModal());
-			const nextSchedule = scheduleData[scheduleIndex + 1] || scheduleData[scheduleIndex - 1];
-			if (nextSchedule) {
-				setFormValues(nextSchedule);
-			} else {
+		if (Object.keys(newErrors).length === 0) {
+			const workingTime: TWorkingTimes = convertWorkTimeForFirestore(workTime);
+			const success = await createPersonalSchedule(workDate, workingTime, memo);
+			if (success) {
 				dispatch(closeModal());
+				resetForm();
+			} else {
+				console.error('Failed to create personal schedule');
 			}
 		}
-	}, [dispatch, setFormValues]);
+	}, [workDate, wage, workTime, breakTime, memo, dispatch, resetForm]);
+
+	const handleUpdate = useCallback(async () => {
+		const fields = { workDate, wage, workTime, breakTime, memo };
+		const newErrors = validateFields(fields);
+		setErrors(newErrors);
+
+		if (Object.keys(newErrors).length === 0) {
+			const workingTime: TWorkingTimes = convertWorkTimeForFirestore(workTime);
+			const oldWorkingTime: TWorkingTimes = schedules[0].workTime as TWorkingTimes; // Assuming the first schedule is being edited
+			const success = await updatePersonalSchedule(
+				workDate,
+				oldWorkingTime,
+				workingTime,
+				memo,
+			);
+			if (success) {
+				dispatch(closeModal());
+				resetForm();
+			} else {
+				console.error('Failed to update personal schedule');
+			}
+		}
+	}, [workDate, wage, workTime, breakTime, memo, schedules, dispatch, resetForm]);
+
+	const handleDelete = useCallback(async () => {
+		const fields = { workDate, workTime };
+		const newErrors = validateFields(fields);
+		setErrors(newErrors);
+
+		if (Object.keys(newErrors).length === 0) {
+			const workingTime: TWorkingTimes = convertWorkTimeForFirestore(workTime);
+			const success = await deletePersonalSchedule(workDate, workingTime);
+			if (success) {
+				dispatch(closeModal());
+				resetForm();
+			} else {
+				console.error('Failed to delete personal schedule');
+			}
+		}
+	}, [workDate, workTime, dispatch, resetForm]);
 
 	const handleEdit = useCallback(() => {
 		dispatch(openModal('edit'));
@@ -149,28 +198,16 @@ const ScheduleModal: React.FC = () => {
 		}
 	}, [content]);
 
-	const getFormattedWorkTime = useCallback((workTime: string) => {
-		if (workTime === 'open') {
-			return '오픈 (07:00~12:00)';
-		} else if (workTime === 'middle') {
-			return '미들 (12:00~17:00)';
-		} else if (workTime === 'close') {
-			return '마감 (17:00~22:00)';
-		} else {
-			return workTime;
-		}
-	}, []);
-
 	if (!isOpen) return null;
 
 	return (
 		<ModalOverlay onClick={handleOverlayClick}>
-			<ModalContent onClick={(e) => e.stopPropagation()}>
+			<ModalContent>
 				<ModalHeaderComponent title={getTitle()} />
 				<ModalFormComponent
 					workDate={workDate}
 					wage={wage}
-					workTime={getFormattedWorkTime(workTime)}
+					workTime={workTime}
 					breakTime={breakTime}
 					memo={memo}
 					isFieldDisabled={isFieldDisabled}
@@ -186,9 +223,8 @@ const ScheduleModal: React.FC = () => {
 					content={content}
 					handleDelete={handleDelete}
 					handleEdit={handleEdit}
-					handleSave={handleSave}
+					handleSave={content === 'edit' ? handleUpdate : handleSave}
 					closeModal={() => {
-						setErrors({});
 						dispatch(closeModal());
 					}}
 				/>

--- a/src/components/SheduleModal/ScheduleModalForm.tsx
+++ b/src/components/SheduleModal/ScheduleModalForm.tsx
@@ -51,7 +51,6 @@ const ModalFormComponent: React.FC<IModalFormProps> = ({
 		} else if (workTime === 'close') {
 			setWorkTime('마감 (17:00~22:00)');
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [workTime]);
 
 	return (
@@ -60,7 +59,7 @@ const ModalFormComponent: React.FC<IModalFormProps> = ({
 				<label>근무일</label>
 				<StyledInput
 					value={workDate}
-					disabled={isFieldDisabled('workDate') || content === 'view'}
+					disabled={true}
 					onChange={handleInputChange(setWorkDate)}
 					className={`workDate ${errors.workDate ? 'error' : ''}`}
 				/>
@@ -70,7 +69,7 @@ const ModalFormComponent: React.FC<IModalFormProps> = ({
 				<StyledInput
 					type="text"
 					value={wage}
-					disabled={isFieldDisabled('wage') || content === 'view'}
+					disabled={true}
 					onChange={handleInputChange(setWage)}
 					className={`wage ${errors.wage ? 'error' : ''}`}
 				/>
@@ -99,6 +98,7 @@ const ModalFormComponent: React.FC<IModalFormProps> = ({
 					onSelect={setWorkTime}
 					disabled={isFieldDisabled('workTime') || content === 'view'}
 					className={`workTime ${errors.workTime ? 'error' : ''}`}
+					defaultLabel="선택"
 				/>
 			</FormGroup>
 			<FormGroup>
@@ -106,7 +106,7 @@ const ModalFormComponent: React.FC<IModalFormProps> = ({
 				<StyledInput
 					type="text"
 					value={breakTime}
-					disabled={isFieldDisabled('breakTime') || content === 'view'}
+					disabled={true}
 					onChange={handleInputChange(setBreakTime)}
 					className={`breakTime ${errors.breakTime ? 'error' : ''}`}
 				/>

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -48,7 +48,7 @@ const Dropdown: React.FC<IDropdownProps> = ({
 					{selectedOptionData?.color && <ColorCircle color={selectedOptionData.color} />}
 					{selectedOptionData?.label || <span>{defaultLabel}</span>}
 				</div>
-				<ChevronDown />
+				<ChevronDown style={{ marginLeft: 'auto', strokeWidth: 1.2 }} />
 			</DropdownButton>
 			{isOpen && (
 				<DropdownMenu>
@@ -112,6 +112,7 @@ const DropdownItem = styled.li`
 	cursor: pointer;
 	display: flex;
 	align-items: center;
+	justify-content: flex-start;
 	&:hover {
 		background-color: ${colors.lightestGray};
 	}

--- a/src/data/mockdata.ts
+++ b/src/data/mockdata.ts
@@ -1,5 +1,3 @@
-import { v4 as uuidv4 } from 'uuid';
-
 export interface IMockDate {
 	userId: string;
 	workDate: string;
@@ -13,7 +11,7 @@ export interface ISchedule {
 	wage: string;
 	workTime: string;
 	breakTime: string;
-	memo: string;
+	memos: string[];
 }
 
 export const mockdata: IMockDate[] = [
@@ -30,52 +28,3 @@ export const mockdata: IMockDate[] = [
 	{ userId: '11', workDate: '2024-08-13', workType: 'middle', isOfficial: true },
 	{ userId: '12', workDate: '2024-08-14', workType: 'close', isOfficial: false },
 ];
-
-export const scheduleData: ISchedule[] = [
-	{
-		userId: '1',
-		workDate: '2024-08-01',
-		wage: '10,030원',
-		workTime: 'middle',
-		breakTime: '30분',
-		memo: '',
-	},
-	{
-		userId: '2',
-		workDate: '2024-07-31',
-		wage: '10,030원',
-		workTime: 'open',
-		breakTime: '30분',
-		memo: '아 퇴근하고 싶다',
-	},
-	{
-		userId: '3',
-		workDate: '2024-07-30',
-		wage: '10,030원',
-		workTime: 'close',
-		breakTime: '30분',
-		memo: '어제 음료수 한개 뺴먹음 ㅋ',
-	},
-];
-
-export const addSchedule = (newSchedule: Omit<ISchedule, 'userId'>) => {
-	const newEntry: ISchedule = { ...newSchedule, userId: uuidv4() };
-	scheduleData.push(newEntry);
-};
-
-export const updateSchedule = (userId: string, updatedData: Partial<ISchedule>) => {
-	const scheduleIndex = scheduleData.findIndex((schedule) => schedule.userId === userId);
-	if (scheduleIndex !== -1) {
-		scheduleData[scheduleIndex] = {
-			...scheduleData[scheduleIndex],
-			...updatedData,
-		};
-	}
-};
-
-export const deleteSchedule = (userId: string) => {
-	const index = scheduleData.findIndex((item) => item.userId === userId);
-	if (index !== -1) {
-		scheduleData.splice(index, 1);
-	}
-};

--- a/src/utils/dateUtils.tsx
+++ b/src/utils/dateUtils.tsx
@@ -1,5 +1,5 @@
 import { Timestamp } from 'firebase/firestore';
-import { IScheduleProps } from '@/hooks/useSchedules';
+import { ISchedule } from '@/pages/Schedule/ScheduleDetail';
 
 export const formatDateWithLeadingZeros = (timestamp: Timestamp) => {
 	const date = timestamp.toDate();
@@ -17,11 +17,11 @@ export const isWeekend = (timestamp: Timestamp): boolean => {
 	return day === 0 || day === 6;
 };
 
-export const sortByWorkType = (a: IScheduleProps, b: IScheduleProps) => {
+export const sortByWorkType = (a: ISchedule, b: ISchedule) => {
 	const workTypeOrder = ['open', 'middle', 'close'];
 
-	const aWorkType = a.workingTimes[0] || '';
-	const bWorkType = b.workingTimes[0] || '';
+	const aWorkType = a.workTime || '';
+	const bWorkType = b.workTime || '';
 
 	return workTypeOrder.indexOf(aWorkType) - workTypeOrder.indexOf(bWorkType);
 };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

모달에서 일정 수정 삭제 추가 기능을 추가했습니다

## 📋 작업 내용

모달에서 일정 수정 삭제 추가 기능을 추가했습니다

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

할일 

일정이 한개도 없을때 일정 추가가 안되는 버그를 고쳐야함   일정이 여러개일때 정렬하면 원하는 일정 조회가 안됌 

실시간으로 반영이 되도록 하기  일정을 수정을 하거나 삭제, 추가를 한 뒤 개인근무 일정표와, 스케쥴 디테일에 실시간으로 반영되게 하기
( 다시 데이터를 새로고침 )

커스텀 훅에서 useState를 사용해서 상태를 관리하게 되면 각각의 컴포넌트가 독립적인 상태 인스턴스를 가지게 됩니다.

예를 들어, 메인 페이지에서 사용하는 schedules 상태와 모달에서 사용하는 schedules 상태가 서로 다른 인스턴스를 갖게 되면서, 같은 값이라도 실제로는 서로 다른 상태가 되는 거죠.

결국, 페이지와 모달에서 사용하는 schedules 상태가 서로 다른 거라, 상태 공유가 안 되는 상황이 생깁니다. 

커스텀 훅은 상태 로직을 분리하는 데는 좋지만, 이렇게 상태를 여러 컴포넌트 간에 공유해야 하는 경우엔 적합하지 않을 수 있어요.

그래서 상태 관리를 좀 더 체계적으로 하기 위해선 Redux Toolkit 사용해서 관리하는게 더 나을수도 있습니다.

리덕스 툴킷을 사용해서 상태관리하기
