### PR TITLE
[feature] 라우팅 시 스크롤 상태 초기화 처리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,9 +13,11 @@ import CorrectionRequest from '@/pages/Wage/Correction/CorrectionRequest';
 import GlobalStyles from '@/styles/GlobalStyles';
 import Layout from '@/layout/Layout';
 import Login from '@/pages/Login';
-import UnderConstruction from './pages/UnderConstruction';
-import { NotFoundPage } from './components/NotFound';
+import UnderConstruction from '@/pages/UnderConstruction';
+import ScrollToTop from '@/components/ScrollToTop';
+import { NotFoundPage } from '@/components/NotFound';
 import { QueryClient, QueryClientProvider } from 'react-query';
+
 export interface IPrivateRouteProps {
 	element: JSX.Element;
 }
@@ -28,6 +30,7 @@ const PrivateRoute = () => {
 const App = () => (
 	<BrowserRouter>
 		<GlobalStyles />
+		<ScrollToTop />
 		<QueryClientProvider client={queryClient}>
 			<Routes>
 				<Route path="/" element={<Layout />}>

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+// 라우팅 시 스크롤을 최상단으로 초기화시키는 로직 컴포넌트
+const ScrollToTop = (): null => {
+	const { pathname } = useLocation();
+
+	useEffect(() => {
+		window.scrollTo(0, 0);
+	}, [pathname]);
+
+	return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

라우팅 시 스크롤 상태 초기화 처리

## 📋 작업 내용

- 라우팅(페이지 이동) 시 스크롤 상태가 최상단으로 초기화 되는 로직을 추가했습니다.

## 🔧 변경 사항

위와 같습니다.

## 📸 스크린샷 (선택 사항)

- 

## 📄 기타

- 
