### PR TITLE
[bug] 개인근무일정페이지에서 일정 추가가 안되는 문제 해결

### DIFF
--- a/src/components/common/Calendar/CalendarBadge.tsx
+++ b/src/components/common/Calendar/CalendarBadge.tsx
@@ -6,13 +6,12 @@ import styled from '@emotion/styled';
 import { FC } from 'react';
 
 export interface ICalendarBadgeProps {
-	workingTimes: string[];
+	workingTime: string;
 }
 
-const CalendarBadge: FC<ICalendarBadgeProps> = ({ workingTimes }) => {
-	const badgeType = workingTimes[0];
+const CalendarBadge: FC<ICalendarBadgeProps> = ({ workingTime }) => {
 	const Badge =
-		BadgeContainer[badgeType as keyof typeof BadgeContainer] || BadgeContainer.default;
+		BadgeContainer[workingTime as keyof typeof BadgeContainer] || BadgeContainer.default;
 
 	const workTypeLabels: { [key: string]: string } = {
 		open: '오픈',
@@ -23,7 +22,7 @@ const CalendarBadge: FC<ICalendarBadgeProps> = ({ workingTimes }) => {
 	return (
 		<Badge>
 			<Clock4 size={14} />
-			{workTypeLabels[badgeType]}
+			{workTypeLabels[workingTime] || workingTime}
 		</Badge>
 	);
 };

--- a/src/components/common/Calendar/CalendarDates.tsx
+++ b/src/components/common/Calendar/CalendarDates.tsx
@@ -25,9 +25,17 @@ const CalendarDates: FC<ICalendarDatesProps> = ({
 	const navigate = useNavigate();
 
 	const formattedDate = formatDateWithLeadingZeros(date);
+
 	const filteredSchedules = schedules
 		.filter((schedule) => schedule.date === formattedDate)
-		.sort(sortByWorkType);
+		.sort(sortByWorkType)
+		.map((schedule) => ({
+			...schedule,
+			workingTimes: [...schedule.workingTimes].sort((a, b) => {
+				const order = ['open', 'middle', 'close'];
+				return order.indexOf(a) - order.indexOf(b);
+			}),
+		}));
 
 	const handleDateClick = () => {
 		if (isCurrentMonth && !isOfficial) {
@@ -50,14 +58,16 @@ const CalendarDates: FC<ICalendarDatesProps> = ({
 			<DayContainer dayType={getDayType(date)} isCurrentMonth={isCurrentMonth}>
 				{date.toDate().getDate()}
 			</DayContainer>
-			<DateListContainer>
-				{filteredSchedules.map((data) => (
-					<CalendarBadge
-						key={`${data.date}-${data.workingTimes}`}
-						workingTimes={data.workingTimes}
-					/>
-				))}
-			</DateListContainer>
+			{filteredSchedules.map((data) => (
+				<DateListContainer key={data.date}>
+					{data.workingTimes.map((workingTime, index) => (
+						<CalendarBadge
+							key={`${data.date}-${workingTime}-${index}`}
+							workingTime={workingTime}
+						/>
+					))}
+				</DateListContainer>
+			))}
 		</DatesContainer>
 	);
 };

--- a/src/utils/dateUtils.tsx
+++ b/src/utils/dateUtils.tsx
@@ -22,8 +22,8 @@ export const getDayType = (timestamp: Timestamp): 'weekday' | 'saturday' | 'sund
 export const sortByWorkType = (a: ISchedule, b: ISchedule) => {
 	const workTypeOrder = ['open', 'middle', 'close'];
 
-	const aWorkType = a.workTime || '';
-	const bWorkType = b.workTime || '';
+	const aWorkType = a.workTime[0] || '';
+	const bWorkType = b.workTime[0] || '';
 
 	return workTypeOrder.indexOf(aWorkType) - workTypeOrder.indexOf(bWorkType);
 };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

개인근무일정페이지에서 일정 추가가 안되는 문제 해결

## 📋 작업 내용

1. 캘린더 뱃지에서, 기존에는 string만 받았는데, 배열을 받아오도록 수정
2. 스케줄을 오픈,미들,마감 순으로 나오도록 로직 수정 

## 📸 스크린샷 (선택 사항)
<img width="427" alt="스크린샷 2024-08-08 오전 11 41 39" src="https://github.com/user-attachments/assets/946e108d-f379-4b1a-b833-5939c10db24f">




