### PR TITLE
[fix] 스케줄 관련 API 날짜 반환 방식 이슈 해결

### DIFF
--- a/src/api/schedule/getOfficialSchedule.ts
+++ b/src/api/schedule/getOfficialSchedule.ts
@@ -18,7 +18,7 @@ const getOfficialSchedule = async (year: number, month: number) => {
 	const officialScheduleArray = docData.map((obj) => {
 		const date = new Date(obj.date.seconds * 1000);
 		const newObj = {
-			date: `${date.getUTCFullYear()}-${date.getUTCMonth() + 1}-${date.getUTCDate()}`,
+			date: `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`,
 			workingTimes: obj.workingTimes,
 			isSub: obj.isSub,
 		};

--- a/src/api/schedule/getPersonalSchedule.ts
+++ b/src/api/schedule/getPersonalSchedule.ts
@@ -18,7 +18,7 @@ const getPersonalSchedule = async (year: number, month: number) => {
 	const personalScheduleArray = docData.map((obj) => {
 		const date = new Date(obj.date.seconds * 1000);
 		const newObj = {
-			date: `${date.getUTCFullYear()}-${date.getUTCMonth() + 1}-${date.getUTCDate()}`,
+			date: `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`,
 			workingTimes: obj.workingTimes,
 			memos: obj.memos,
 		};

--- a/src/api/work/getOfficialWage.ts
+++ b/src/api/work/getOfficialWage.ts
@@ -19,7 +19,7 @@ const getOfficialWage = async (year: number, month: number) => {
 	const officialWageArray = docData.map((obj) => {
 		const date = new Date(obj.date.seconds * 1000);
 		const newObj = {
-			date: `${date.getUTCFullYear()}-${date.getUTCMonth() + 1}-${date.getUTCDate()}`,
+			date: `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`,
 			workingTimes: obj.workingTimes,
 			isSub: obj.isSub,
 		};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

스케줄 관련 API 날짜 반환 방식 이슈 해결

## 📋 작업 내용

- 날짜 값을 반환하는 메소드를 getUTC에서 get으로 변경했습니다.

## 🔧 변경 사항

위와 같습니다.

## 📸 스크린샷 (선택 사항)

- 

## 📄 기타

- 