### PR TITLE
[refactor] 캘린더 2차 수정 작업

### DIFF
--- a/src/components/Home/SummaryInfoCard.tsx
+++ b/src/components/Home/SummaryInfoCard.tsx
@@ -1,56 +1,28 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
-import getOfficialWage from '@/api/work/getOfficialWage';
 import { colors } from '@/constants/colors';
 import { fontSize, fontWeight } from '@/constants/font';
 import characterCheese from '@/assets/character_cheese.svg';
 import styled from '@emotion/styled';
 
 interface IWageDataProps {
-	totalWorkHour: number;
-	totalWage: number;
+	year: number;
+	month: number;
+	wagecount: number;
+	workinghours: number;
 }
 
-const SummaryInfoCard = () => {
-	const [wageData, setWageData] = useState<IWageDataProps | null>(null);
-	const [error, setError] = useState<string | null>(null);
-
-	const dateInfo = useMemo(() => {
-		const today = new Date();
-		const year = today.getFullYear();
-		const month = today.getMonth() + 1;
-		const monthString = month.toString().padStart(2, '0');
-		return { year, month, monthString };
-	}, []);
-
-	const fetchWageData = useCallback(async () => {
-		setError(null);
-		try {
-			const data = await getOfficialWage(dateInfo.year, dateInfo.month);
-			setWageData(data);
-		} catch (error) {
-			setError('급여 정보를 불러오는 데 실패했습니다');
-		}
-	}, [dateInfo.year, dateInfo.month]);
-
-	useEffect(() => {
-		fetchWageData();
-	}, [fetchWageData]);
-
-	if (error) return <p>{error}</p>;
-	if (!wageData) return <p>급여정보가 없습니다.</p>;
-
+const SummaryInfoCard = ({ year, month, wagecount, workinghours }: IWageDataProps) => {
 	return (
 		<SummaryCard>
 			<SummaryCardContainer>
 				<FirstSection>
 					<p>
-						공식 근무 스케줄 | {dateInfo.year}년 {dateInfo.monthString}월
+						공식 근무 스케줄 | {year}년 {month.toString().padStart(2, '0')}월
 					</p>
-					<p>근무 시간 | {wageData.totalWorkHour}시간</p>
+					<p>근무 시간 | {workinghours}시간</p>
 				</FirstSection>
 				<SecondSection>
 					<p>예상 급여액</p>
-					<p>{wageData.totalWage.toLocaleString()}원</p>
+					<p>{wagecount.toLocaleString()}원</p>
 				</SecondSection>
 			</SummaryCardContainer>
 			<img src={characterCheese} alt="치즈캐릭터" />

--- a/src/components/common/Calendar/CalendarDates.tsx
+++ b/src/components/common/Calendar/CalendarDates.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Timestamp } from 'firebase/firestore';
 import { colors } from '@/constants/colors';
@@ -23,29 +23,36 @@ const CalendarDates: FC<ICalendarDatesProps> = ({
 	currentMonth,
 }) => {
 	const navigate = useNavigate();
-
+	const [filteredSchedules, setFilteredSchedules] = useState<IScheduleProps[]>([]);
+	const [isCurrentMonth, setIsCurrentMonth] = useState(false);
 	const formattedDate = formatDate(date, true, 'line');
-
-	const filteredSchedules = schedules
-		.filter((schedule) => schedule.date === formattedDate)
-		.sort(sortByWorkType)
-		.map((schedule) => ({
-			...schedule,
-			workingTimes: [...schedule.workingTimes].sort((a, b) => {
-				const order = ['open', 'middle', 'close'];
-				return order.indexOf(a) - order.indexOf(b);
-			}),
-		}));
 
 	const handleDateClick = () => {
 		if (isCurrentMonth && !isOfficial) {
-			const dateString = formatDate(date, true, 'line');
-			navigate(`/schedule/${dateString}`);
+			navigate(`/schedule/${formattedDate}`);
 		}
 	};
 
-	const isCurrentMonth =
-		date.toDate().getMonth() === currentMonth && date.toDate().getFullYear() === currentYear;
+	useEffect(() => {
+		const filtered = schedules
+			.filter((schedule) => schedule.date === formattedDate)
+			.sort(sortByWorkType)
+			.map((schedule) => ({
+				...schedule,
+				workingTimes: [...schedule.workingTimes].sort((a, b) => {
+					const order = ['open', 'middle', 'close'];
+					return order.indexOf(a) - order.indexOf(b);
+				}),
+			}));
+		setFilteredSchedules(filtered);
+	}, [schedules, formattedDate]);
+
+	useEffect(() => {
+		const cellDate = date.toDate();
+		setIsCurrentMonth(
+			cellDate.getMonth() === currentMonth && cellDate.getFullYear() === currentYear,
+		);
+	}, [date, currentMonth, currentYear]);
 
 	return (
 		<DatesContainer

--- a/src/components/common/Calendar/CalenderContents.tsx
+++ b/src/components/common/Calendar/CalenderContents.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useMemo, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { Timestamp } from 'firebase/firestore';
 import CalendarWeek from '@/components/common/Calendar/CalendarWeek';
 import CalendarDates from '@/components/common/Calendar/CalendarDates';
@@ -11,31 +11,37 @@ export interface ICalenderDateProps {
 	isOfficial: boolean;
 }
 
-const CalenderContents: FC<ICalenderDateProps> = ({ nowDate, isOfficial }) => {
-	const [currentDate, setCurrentDate] = useState(nowDate.toDate());
-	const [currentYear, setCurrentYear] = useState(currentDate.getFullYear());
-	const [currentMonth, setCurrentMonth] = useState(currentDate.getMonth());
+interface IDateStateProps {
+	date: Date;
+	year: number;
+	month: number;
+}
 
-	const calendarDates = useMemo(() => monthList(nowDate), [nowDate]);
-	const schedules = useSchedules(currentYear, currentMonth + 1, isOfficial);
+const CalenderContents: FC<ICalenderDateProps> = ({ nowDate, isOfficial }) => {
+	const [date, setDate] = useState<IDateStateProps>({} as IDateStateProps);
+	const [calendarDates, setCalendarDates] = useState<Timestamp[]>([]);
+	const schedules = useSchedules(date.year, date.month + 1, isOfficial);
 
 	useEffect(() => {
-		const today = nowDate.toDate();
-		setCurrentDate(today);
-		setCurrentYear(today.getFullYear());
-		setCurrentMonth(today.getMonth());
+		const currentDate = nowDate.toDate();
+		setDate({
+			date: currentDate,
+			year: currentDate.getFullYear(),
+			month: currentDate.getMonth(),
+		});
+		setCalendarDates(monthList(nowDate));
 	}, [nowDate]);
 
 	return (
 		<div>
 			<CalendarWeek />
 			<CalendarDatesWrap>
-				{calendarDates.map((date: Timestamp) => (
+				{calendarDates.map((day: Timestamp) => (
 					<CalendarDates
-						key={date.toMillis().toString()}
-						date={date}
-						currentYear={currentYear}
-						currentMonth={currentMonth}
+						key={day.toMillis().toString()}
+						date={day}
+						currentYear={date.year}
+						currentMonth={date.month}
 						isOfficial={isOfficial}
 						schedules={schedules}
 					/>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,11 +2,23 @@ import SummaryInfoCard from '@/components/Home/SummaryInfoCard';
 import Calendar from '@/components/common/Calendar/Calendar';
 import Title from '@/components/common/Title';
 import styled from '@emotion/styled';
+import useWageCheck from '@/hooks/useWageCheck';
 
 const Home = () => {
+	const { year, month, officialWageData, officialWageError, getErrorMessage } = useWageCheck();
+
+	if (officialWageError) {
+		return <div>Error: {getErrorMessage(officialWageError)}</div>;
+	}
+
 	return (
 		<Container>
-			<SummaryInfoCard />
+			<SummaryInfoCard
+				year={year}
+				month={month}
+				wagecount={officialWageData?.totalWage || 0}
+				workinghours={officialWageData?.totalWorkHour || 0}
+			/>
 			<Title title="공식 근무 스케줄" className="title" />
 			<Calendar isOfficial={true} />
 		</Container>


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

멘토님 피드백 반영하여 캘린더 2차 수정 작업

## 📋 작업 내용
- SummaryInfoCard 컴포넌트에서 직접 api를 패치해오던 것을, Home 페이지에서 useWageCheck로 패치해와 SummaryInfoCard에 props로 넘겨주는 방식으로 변경: 코드가 깔끔해짐
- 캘린더 컴포넌트들을 useState와 useEffect로 상태관리하여 불필요한 렌더링을 줄임